### PR TITLE
Improved error handling while traversing

### DIFF
--- a/src/components/Component.js
+++ b/src/components/Component.js
@@ -76,6 +76,7 @@ class Component {
 
   /** Exit gracefully. */
   cleanAndExit() {
+    this.newline();
     this.write(this.ansi.cursorShow);
     process.exit();
   }

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -6,6 +6,7 @@ class List extends Component {
 
     this.styles = styles;
     this.question = question.question;
+    this.questionId = question.id;
     this.options = question.options;
 
     this.chosen = 0;
@@ -13,6 +14,9 @@ class List extends Component {
 
   init() {
     return new Promise(resolve => {
+      if (!this.options || !this.options.length)
+        this.throw(`couldn't find options in question '${this.questionId}'`);
+
       this.onKeyEnter = () => {
         this.clear();
         resolve(this.options[this.chosen]);

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -14,8 +14,11 @@ class List extends Component {
 
   init() {
     return new Promise(resolve => {
-      if (!this.options || !this.options.length)
-        this.throw(`couldn't find options in question '${this.questionId}'`);
+      if (!this.options || !this.options.length) {
+        throw `Invalid configuration - Could not find options in question '${
+          this.questionId
+        }'`;
+      }
 
       this.onKeyEnter = () => {
         this.clear();

--- a/src/components/ListToggle.js
+++ b/src/components/ListToggle.js
@@ -6,14 +6,18 @@ class ListToggle extends Component {
 
     this.styles = styles;
     this.question = question.question;
+    this.questionId = question.id;
     this.options = question.options;
 
-    this.selected = new Array(this.options.length);
+    this.selected = new Array(this.options && this.options.length);
     this.chosen = 0;
   }
 
   init() {
     return new Promise(resolve => {
+      if (!this.options || !this.options.length)
+        this.throw(`couldn't find options in question '${this.questionId}'`);
+
       this.onKeyEnter = () => {
         this.clear();
         resolve({

--- a/src/components/ListToggle.js
+++ b/src/components/ListToggle.js
@@ -15,8 +15,11 @@ class ListToggle extends Component {
 
   init() {
     return new Promise(resolve => {
-      if (!this.options || !this.options.length)
-        this.throw(`couldn't find options in question '${this.questionId}'`);
+      if (!this.options || !this.options.length) {
+        throw `Invalid configuration - Could not find options in question '${
+          this.questionId
+        }'`;
+      }
 
       this.onKeyEnter = () => {
         this.clear();

--- a/src/components/Wizard.js
+++ b/src/components/Wizard.js
@@ -67,9 +67,7 @@ class Wizard extends Component {
     return new Promise(async (resolve, reject) => {
       if (!this.validateSection(section)) {
         reject(
-          new Error(
-            `Invalid configuration — check the docs to ensure the question was written by the rules`,
-          ),
+          new Error(`Invalid configuration - There is an error in your config`),
         );
       }
 
@@ -99,9 +97,9 @@ class Wizard extends Component {
             this.write(this.ansi.cursorShow);
             reject(
               new Error(
-                `Invalid configuration — couldn't find 'then' key in '${
+                `Invalid configuration - Could not find key 'then' in section '${
                   section.id
-                }' section`,
+                }`,
               ),
             );
             return null;
@@ -111,15 +109,15 @@ class Wizard extends Component {
             this.write(this.ansi.cursorShow);
             reject(
               new Error(
-                `Invalid configuration — couldn't find key '${
+                `Invalid configuration — Could not find key '${
                   response.then
-                }' in 'then' of '${section.id}' section`,
+                }' in 'then' of section '${section.id}'`,
               ),
             );
             return null;
           }
         } catch (err) {
-          reject(`A component error occured — ${err}`);
+          reject(err);
         }
 
         this.write(this.ansi.cursorShow);
@@ -127,7 +125,13 @@ class Wizard extends Component {
         return null;
       }
       this.write(this.ansi.cursorShow);
-      reject(new Error('Invalid configuration'));
+      reject(
+        new Error(
+          `Invalid configuration - Unknown component type '${
+            section.type
+          }' referenced`,
+        ),
+      );
       return null;
     })
       .then(results => {


### PR DESCRIPTION
Fixed some bugs and improve error handling in traversing:
- Changed error messages — now it's more clear what was wrong with configurations,
- Add options check in List and ListToggle components,
- Handled a case when there were both `section.then` and `response.then`, but such key as `response.then` wasn't found in `section.then` (I found it a very useful case during my own project where I used Wizard),
- Changed `validateSection` because it didn't check all must-have properties,
- Changed try-catch to .catch, because try-catch couldn't handle promise errors.